### PR TITLE
FUNCAKE-87 Replace textual delimiter

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,58 +98,59 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field "title_ssim", label: "Title", helper_method: :delimited_link_to_facet
-    config.add_show_field "alternativeTitle_ssim", label: "Alternative Title", helper_method: :delimited_link_to_facet
-    config.add_show_field "creator_ssim", label: "Creator", helper_method: :delimited_link_to_facet
+    facet_separator_options = { words_connector: "; ", two_words_connector: "; ", last_word_connector: "; " }
+    config.add_show_field "title_ssim", label: "Title", helper_method: :autolinker, separator_options: facet_separator_options 
+    config.add_show_field "alternativeTitle_ssim", label: "Alternative Title", helper_method: :autolinker, separator_options: facet_separator_options
+    config.add_show_field "creator_ssim", label: "Creator", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "contributor_ssim", label: "Contributor", helper_method: :delimited_link_to_facet
-    config.add_show_field "subject_ssim", label: "Subject", helper_method: :delimited_link_to_facet
-    config.add_show_field "spatial_ssim", label: "Place", helper_method: :delimited_link_to_facet
+    config.add_show_field "contributor_ssim", label: "Contributor", link_to_facet: true, separator_options: facet_separator_options
+    config.add_show_field "subject_ssim", label: "Subject", link_to_facet: true, separator_options: facet_separator_options
+    config.add_show_field "spatial_ssim", label: "Place", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "temporalCoverage_ssim", label: "Temporal Coverage", helper_method: :delimited_link_to_facet
+    config.add_show_field "temporalCoverage_ssim", label: "Temporal Coverage", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "type_ssim", label: "Type", helper_method: :delimited_link_to_facet
+    config.add_show_field "type_ssim", label: "Type", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "format_ssim", label: "Format", helper_method: :delimited_link_to_facet
+    config.add_show_field "format_ssim", label: "Format", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "language_ssim", label: "Language", helper_method: :delimited_link_to_facet
+    config.add_show_field "language_ssim", label: "Language", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "date_ssim", label: "Date", helper_method: :delimited_link_to_facet
+    config.add_show_field "date_ssim", label: "Date", link_to_facet: true, separator_options: facet_separator_options
 
     config.add_show_field "description_tsim", label: "Description", helper_method: :autolinker
-    config.add_show_field "extent_ssim", label: "Extent", helper_method: :delimited_link_to_facet
+    config.add_show_field "extent_ssim", label: "Extent", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "publisher_ssim", label: "Publisher", helper_method: :delimited_link_to_facet
+    config.add_show_field "publisher_ssim", label: "Publisher", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "relation_ssim", label: "Relation", link_to_facet: true, helper_method: :autolinker
+    config.add_show_field "relation_ssim", label: "Relation", link_to_facet: true
 
-    config.add_show_field "replacedBy_ssim", label: "Replaced By", helper_method: :delimited_link_to_facet
+    config.add_show_field "replacedBy_ssim", label: "Replaced By", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "replaces_ssim", label: "Replaces", helper_method: :delimited_link_to_facet
+    config.add_show_field "replaces_ssim", label: "Replaces", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "rightsHolder_ssim", label: "Rights Holder", helper_method: :delimited_link_to_facet
+    config.add_show_field "rightsHolder_ssim", label: "Rights Holder", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "source_ssim", label: "Source", helper_method: :delimited_link_to_facet
+    config.add_show_field "source_ssim", label: "Source", link_to_facet: true, separator_options: facet_separator_options
 
     config.add_show_field 'id', label: "Identifier"
 
-    config.add_show_field "fileFormat_ssim",  label: "File Format", helper_method: :delimited_link_to_facet
+    config.add_show_field "fileFormat_ssim",  label: "File Format", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "rights_ssim",  label: "Rights", helper_method: :autolinker
-    config.add_show_field "rightsUri_tsim",  label: "Rights Link", helper_method: :delimited_link_to_facet
+    config.add_show_field "rights_ssim",  label: "Rights", link_to_facet: true
+    config.add_show_field "rightsUri_tsim",  label: "Rights Link", helper_method: :autolinker, separator_options: facet_separator_options
 
-    config.add_show_field "collection_ssim", label: "Collection", helper_method: :delimited_link_to_facet
+    config.add_show_field "collection_ssim", label: "Collection", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "genre_ssim", label: "Genre", helper_method: :delimited_link_to_facet
+    config.add_show_field "genre_ssim", label: "Genre", link_to_facet: true, separator_options: facet_separator_options
 
-    config.add_show_field "iiifManifest_ssim",  label: "IIIF Manifest", helper_method: :delimited_link_to_facet
-    config.add_show_field "iiifBaseUrl_ssim",  label: "IIIF Base URL", helper_method: :delimited_link_to_facet
+    config.add_show_field "iiifManifest_ssim",  label: "IIIF Manifest", helper_method: :autolinker, separator_options: facet_separator_options
+    config.add_show_field "iiifBaseUrl_ssim",  label: "IIIF Base URL", helper_method: :autolinker, separator_options: facet_separator_options
 
-    config.add_show_field  "contributingInstitution_tsim", label: "Contributing Institution", helper_method: :delimited_link_to_facet
-    config.add_show_field  "url_ssim", label: "URL", helper_method: :autolinker
-    config.add_show_field  "intermediateProvider_ssim", label: "Intermediate Provider", helper_method: :delimited_link_to_facet
+    config.add_show_field  "contributingInstitution_tsim", label: "Contributing Institution", helper_method: :autolinker, separator_options: facet_separator_options
+    config.add_show_field  "url_ssim", label: "URL", helper_method: :autolinker, separator_options: facet_separator_options
+    config.add_show_field  "intermediateProvider_ssim", label: "Intermediate Provider", link_to_facet: true, separator_options: facet_separator_options
     config.add_show_field  "preview_ssim", label: "Preview", helper_method: :autolinker
-    config.add_show_field  "provider_ssim", label: "Provider", helper_method: :delimited_link_to_facet
+    config.add_show_field  "provider_ssim", label: "Provider", link_to_facet: true, separator_options: facet_separator_options
 
 # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -36,7 +36,7 @@ class CatalogController < ApplicationController
 
     config.add_results_document_tool(:bookmark, partial: 'bookmark_control', if: :render_bookmarks_control?)
 
-    config.add_results_collection_tool(:sort_widget)
+    config.add_results_collection_tool(:sort_widget) # => 
     config.add_results_collection_tool(:per_page_widget)
     config.add_results_collection_tool(:view_type_group)
 
@@ -99,27 +99,27 @@ class CatalogController < ApplicationController
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
     config.add_show_field "title_ssim", label: "Title"
-    config.add_show_field "alternativeTitle_ssim", label: "Alternative Title"
-    config.add_show_field "creator_ssim", label: "Creator", link_to_facet: true
+    config.add_show_field "alternativeTitle_ssim", label: "Alternative Title", helper_method: :delimited_link_to_facet
+    config.add_show_field "creator_ssim", label: "Creator", helper_method: :delimited_link_to_facet
 
     config.add_show_field "contributor_ssim", label: "Contributor", link_to_facet: true
     config.add_show_field "subject_ssim", label: "Subject", helper_method: :delimited_link_to_facet
-    config.add_show_field "spatial_ssim", label: "Place", link_to_facet: true
+    config.add_show_field "spatial_ssim", label: "Place", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "temporalCoverage_ssim", label: "Temporal Coverage", link_to_facet: true
+    config.add_show_field "temporalCoverage_ssim", label: "Temporal Coverage", helper_method: :delimited_link_to_facet
 
     config.add_show_field "type_ssim", label: "Type", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "format_ssim", label: "Format", link_to_facet: true
+    config.add_show_field "format_ssim", label: "Format", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "language_ssim", label: "Language", link_to_facet: true
+    config.add_show_field "language_ssim", label: "Language", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "date_ssim", label: "Date", link_to_facet: true
+    config.add_show_field "date_ssim", label: "Date", helper_method: :delimited_link_to_facet
 
     config.add_show_field "description_tsim", label: "Description", helper_method: "autolinker"
-    config.add_show_field "extent_ssim", label: "Extent", link_to_facet: true
+    config.add_show_field "extent_ssim", label: "Extent", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "publisher_ssim", label: "Publisher", link_to_facet: true
+    config.add_show_field "publisher_ssim", label: "Publisher", helper_method: :delimited_link_to_facet
 
     config.add_show_field "relation_ssim", label: "Relation", link_to_facet: true, helper_method: "autolinker"
 
@@ -127,17 +127,19 @@ class CatalogController < ApplicationController
 
     config.add_show_field "replaces_ssim", label: "Replaces", link_to_facet: true
 
-    config.add_show_field "rightsHolder_ssim", label: "Rights Holder", link_to_facet: true
+    config.add_show_field "rightsHolder_ssim", label: "Rights Holder", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "source_ssim", label: "Source", link_to_facet: true
+    config.add_show_field "source_ssim", label: "Source", helper_method: :delimited_link_to_facet
 
     config.add_show_field 'id', label: "Identifier"
 
-    config.add_show_field "fileFormat_ssim",  label: "File Format", link_to_facet: true
+    config.add_show_field "fileFormat_ssim",  label: "File Format", helper_method: :delimited_link_to_facet
 
-    #config.add_show_field "collection_ssim", label: "Collection"
+    config.add_show_field "rights_ssim",  label: "Rights", helper_method: "autolinker"
 
-    #config.add_show_field "genre_ssim", label: "Genre"
+    config.add_show_field "collection_ssim", label: "Collection", helper_method: :delimited_link_to_facet
+
+    config.add_show_field "genre_ssim", label: "Genre", helper_method: :delimited_link_to_facet
 
     #config.add_show_field "fileFormat_ssim",  label: "FileFormat"
     config.add_show_field "rights_tsim",  label: "Rights", helper_method: "autolinker"

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -98,11 +98,11 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
-    config.add_show_field "title_ssim", label: "Title"
+    config.add_show_field "title_ssim", label: "Title", helper_method: :delimited_link_to_facet
     config.add_show_field "alternativeTitle_ssim", label: "Alternative Title", helper_method: :delimited_link_to_facet
     config.add_show_field "creator_ssim", label: "Creator", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "contributor_ssim", label: "Contributor", link_to_facet: true
+    config.add_show_field "contributor_ssim", label: "Contributor", helper_method: :delimited_link_to_facet
     config.add_show_field "subject_ssim", label: "Subject", helper_method: :delimited_link_to_facet
     config.add_show_field "spatial_ssim", label: "Place", helper_method: :delimited_link_to_facet
 
@@ -116,16 +116,16 @@ class CatalogController < ApplicationController
 
     config.add_show_field "date_ssim", label: "Date", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "description_tsim", label: "Description", helper_method: "autolinker"
+    config.add_show_field "description_tsim", label: "Description", helper_method: :autolinker
     config.add_show_field "extent_ssim", label: "Extent", helper_method: :delimited_link_to_facet
 
     config.add_show_field "publisher_ssim", label: "Publisher", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "relation_ssim", label: "Relation", link_to_facet: true, helper_method: "autolinker"
+    config.add_show_field "relation_ssim", label: "Relation", link_to_facet: true, helper_method: :autolinker
 
-    config.add_show_field "replacedBy_ssim", label: "Replaced By", link_to_facet: true
+    config.add_show_field "replacedBy_ssim", label: "Replaced By", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "replaces_ssim", label: "Replaces", link_to_facet: true
+    config.add_show_field "replaces_ssim", label: "Replaces", helper_method: :delimited_link_to_facet
 
     config.add_show_field "rightsHolder_ssim", label: "Rights Holder", helper_method: :delimited_link_to_facet
 
@@ -135,24 +135,21 @@ class CatalogController < ApplicationController
 
     config.add_show_field "fileFormat_ssim",  label: "File Format", helper_method: :delimited_link_to_facet
 
-    config.add_show_field "rights_ssim",  label: "Rights", helper_method: "autolinker"
+    config.add_show_field "rights_ssim",  label: "Rights", helper_method: :autolinker
+    config.add_show_field "rightsUri_tsim",  label: "Rights Link", helper_method: :delimited_link_to_facet
 
     config.add_show_field "collection_ssim", label: "Collection", helper_method: :delimited_link_to_facet
 
     config.add_show_field "genre_ssim", label: "Genre", helper_method: :delimited_link_to_facet
 
-    #config.add_show_field "fileFormat_ssim",  label: "FileFormat"
-    config.add_show_field "rights_tsim",  label: "Rights", helper_method: "autolinker"
-    config.add_show_field "rightsUri_tsim",  label: "Rights Link", link_to_facet: true
-    #config.add_show_field "iiifManifest_ssim",  label: "IIIF Manifest"
-    #config.add_show_field "iiifBaseUrl_ssim",  label: "IIIF Base URL"
+    config.add_show_field "iiifManifest_ssim",  label: "IIIF Manifest", helper_method: :delimited_link_to_facet
+    config.add_show_field "iiifBaseUrl_ssim",  label: "IIIF Base URL", helper_method: :delimited_link_to_facet
 
-    #config.add_show_field  "dataProvider_ssim", label: "Data Provider"
-    config.add_show_field  "contributingInstitution_tsim", label: "Contributing Institution", link_to_facet: true
-    #config.add_show_field  "url_display", label: "URL"
-    #config.add_show_field  "intermediateProvider_display", label: "Intermediate Provider"
-    #config.add_show_field  "preview_display", label: "Preview"
-    #config.add_show_field  "provider_display", label: "Provider"
+    config.add_show_field  "contributingInstitution_tsim", label: "Contributing Institution", helper_method: :delimited_link_to_facet
+    config.add_show_field  "url_ssim", label: "URL", helper_method: :autolinker
+    config.add_show_field  "intermediateProvider_ssim", label: "Intermediate Provider", helper_method: :delimited_link_to_facet
+    config.add_show_field  "preview_ssim", label: "Preview", helper_method: :autolinker
+    config.add_show_field  "provider_ssim", label: "Provider", helper_method: :delimited_link_to_facet
 
 # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -103,12 +103,12 @@ class CatalogController < ApplicationController
     config.add_show_field "creator_ssim", label: "Creator", link_to_facet: true
 
     config.add_show_field "contributor_ssim", label: "Contributor", link_to_facet: true
-    config.add_show_field "subject_ssim", label: "Subject", link_to_facet: true
+    config.add_show_field "subject_ssim", label: "Subject", helper_method: :delimited_link_to_facet
     config.add_show_field "spatial_ssim", label: "Place", link_to_facet: true
 
     config.add_show_field "temporalCoverage_ssim", label: "Temporal Coverage", link_to_facet: true
 
-    config.add_show_field "type_ssim", label: "Type", link_to_facet: true
+    config.add_show_field "type_ssim", label: "Type", helper_method: :delimited_link_to_facet
 
     config.add_show_field "format_ssim", label: "Format", link_to_facet: true
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -6,10 +6,4 @@ module BlacklightHelper
   def autolinker(text, options = {})
     return Autolinker.parse(text[:value].first).html_safe
   end
-
-  def delimited_link_to_facet(args)
-    args[:document][args[:field]].map { |item|
-			link_to item, "/?f[#{args[:field]}][]=#{item}"
-		}.join("; ").html_safe
-  end
 end

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -6,4 +6,10 @@ module BlacklightHelper
   def autolinker(text, options = {})
     return Autolinker.parse(text[:value].first).html_safe
   end
+
+  def delimited_link_to_facet(args)
+    args[:document][args[:field]].map { |item|
+			link_to item, "/?f[#{args[:field]}][]=#{item}"
+		}.join("; ").html_safe
+  end
 end


### PR DESCRIPTION
Replace out-of-the-box blacklight delimiting with semicolon. As is, things display as follows:
Thing1, Thing2, Thing3, and Thing4

It should read:
Thing1 ; Thing2 ; Thing3 ; Thing4

Applied to fields:
- alternative title
- creator
- subject
- spatial
- temporal coverage
- type
- format
- language
- date
- extent
- publisher
- rights holder
- file format
- rights
- collection
- genre

 
