### PR TITLE
Ensures we're showing the right fields

### DIFF
--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -89,12 +89,10 @@ class CatalogController < ApplicationController
 
     # solr fields to be displayed in the index (search results) view
     #   The ordering of the field names is the order of the display
-    config.add_index_field "id", label: "ID"
-    config.add_index_field "creator_ssim", label: "Creator"
-    config.add_index_field "format_ssim", label: "Format"
-    config.add_index_field "language_ssim", label: "Language"
-    config.add_index_field "date_ssim", label: "Published"
-    config.add_index_field "description_tsim", label: "Description"
+    config.add_index_field "type_ssim", label: "Type"
+    config.add_index_field "contributingInstitution_ssim", label: "Contributing Institution"
+    config.add_index_field "intermediateProvider_ssim", label: "Intermediate Provider"
+    config.add_index_field "collection_ssim", label: "Collection"
 
     # solr fields to be displayed in the show (single result) view
     #   The ordering of the field names is the order of the display
@@ -146,12 +144,11 @@ class CatalogController < ApplicationController
     config.add_show_field "iiifManifest_ssim",  label: "IIIF Manifest", helper_method: :autolinker, separator_options: facet_separator_options
     config.add_show_field "iiifBaseUrl_ssim",  label: "IIIF Base URL", helper_method: :autolinker, separator_options: facet_separator_options
 
-    config.add_show_field  "contributingInstitution_tsim", label: "Contributing Institution", helper_method: :autolinker, separator_options: facet_separator_options
+    config.add_show_field  "contributingInstitution_ssim", label: "Contributing Institution", link_to_facet: true
     config.add_show_field  "url_ssim", label: "URL", helper_method: :autolinker, separator_options: facet_separator_options
     config.add_show_field  "intermediateProvider_ssim", label: "Intermediate Provider", link_to_facet: true, separator_options: facet_separator_options
     config.add_show_field  "preview_ssim", label: "Preview", helper_method: :autolinker
     config.add_show_field  "provider_ssim", label: "Provider", link_to_facet: true, separator_options: facet_separator_options
-    config.add_show_field  "contributingInstitution_ssim", label: "Contributing Institution", link_to_facet: true
 
 # "fielded" search configuration. Used by pulldown among other places.
     # For supported keys in hash, see rdoc for Blacklight::SearchFields


### PR DESCRIPTION
Addresses Issue #FUNCAKE-84

- Restores fields possibly lost during Git merge
- Removes redundant contributing institution field
- Updates field suffixes as applicable