### PR TITLE
FUNCAKE-86 Remove row class for metadata list

### DIFF
--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -5,7 +5,7 @@
 </div>
 
 <%# default partial to display solr document fields in catalog show view -%>
-<dl class="row dl-invert document-metadata">
+<dl class="dl-invert document-metadata">
   <% doc_presenter.fields_to_render.each do |field_name, field| -%>
     <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
     <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>


### PR DESCRIPTION
- Safari spans the width with the `row` class. Since we're not using columns, remove the row class from the `dl` metadata block. This will let the thumbnail float right rather than being placed on its own line between the header and the `dl` metadata block.