### PR TITLE
FUNCAKE-86 Group all metadata together with thumbnail

### DIFF
--- a/app/assets/stylesheets/oai_recs.css.scss
+++ b/app/assets/stylesheets/oai_recs.css.scss
@@ -3,12 +3,17 @@
 }
 
 .show-thumbnail{
-	float: right;
 	padding: 10px;
 	img {
 		width: 150px;
 	}
-} 
+}
+
+.document-metadata {
+  .col-md-9 {
+    overflow-wrap: break-word;
+  }
+}
 
 .default-thumbnail {
 	background: asset-data-url('default-thumbnail.png') no-repeat;

--- a/app/views/catalog/_show.html.erb
+++ b/app/views/catalog/_show.html.erb
@@ -1,13 +1,19 @@
 <% doc_presenter = show_presenter(document) %>
 
-<div class="show-thumbnail">
-  <%= render_default_thumbnail_link @document %>
-</div>
 
 <%# default partial to display solr document fields in catalog show view -%>
-<dl class="row dl-invert document-metadata">
-  <% doc_presenter.fields_to_render.each do |field_name, field| -%>
-    <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
-    <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
-  <% end -%>
-</dl>
+<div class="row">
+  <div class="col-10">
+    <dl class="row dl-invert document-metadata">
+      <% doc_presenter.fields_to_render.each do |field_name, field| -%>
+        <dt class="blacklight-<%= field_name.parameterize %> col-md-3"><%= render_document_show_field_label document, field: field_name %></dt>
+        <dd class="blacklight-<%= field_name.parameterize %> col-md-9"><%= doc_presenter.field_value field %></dd>
+      <% end -%>
+    </dl>
+  </div>
+  <div class="show-thumbnail col-2">
+    <div>
+      <%= render_default_thumbnail_link @document %>
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
Addresses issues in #FUNCAKE-86 where thumbnail appears on a separate line when viewed in the Safari browser.

- Group thumbnail with whole metadata block in a single row