### PR TITLE
FLYPIE-176: Fix null value breaks preview search.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,7 +8,8 @@ ruby "2.7.2"
 gem "rails", "~> 5.2.2"
 
 gem "blacklight"
-gem "blacklight_oai_provider", github: "projectblacklight/blacklight_oai_provider"
+#gem "blacklight_oai_provider", github: "projectblacklight/blacklight_oai_provider"
+gem "blacklight_oai_provider", github: "ubiquitypress/blacklight_oai_provider", branch: "multi_tenant_improvements"
 gem "bootsnap", ">= 1.1.0", require: false
 gem "fieldhand"
 gem "funnel_cake_index", github: "tulibraries/funnel_cake_index"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,12 +1,4 @@
 GIT
-  remote: https://github.com/projectblacklight/blacklight_oai_provider.git
-  revision: 76b6a2ae6fc0068aa93a3035051fb333c4564795
-  specs:
-    blacklight_oai_provider (7.0.0)
-      blacklight (~> 7.0)
-      oai (~> 1.0)
-
-GIT
   remote: https://github.com/tulibraries/funnel_cake_index.git
   revision: 09ef38680d4e21996e731cc7492e458210307dd6
   specs:
@@ -15,6 +7,15 @@ GIT
       library_stdnums (~> 1.6)
       rsolr (~> 2.2)
       traject (~> 3.1)
+
+GIT
+  remote: https://github.com/ubiquitypress/blacklight_oai_provider.git
+  revision: 8821dadbcc861a988d14be5b053c7fc13a77ed31
+  branch: multi_tenant_improvements
+  specs:
+    blacklight_oai_provider (7.0.0)
+      blacklight (~> 7.0)
+      oai (~> 1.0)
 
 GEM
   remote: https://rubygems.org/

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -34,6 +34,8 @@ class CatalogController < ApplicationController
     #config.index.display_type_field = 'format'
     #config.index.thumbnail_field = 'thumbnail_path_ss'
     config.index.thumbnail_field = "preview_ssim"
+    config.index.document_presenter_class = ::FunnelCake::IndexPresenter
+    config.show.document_presenter_class = ::FunnelCake::ShowPresenter
 
     config.add_results_document_tool(:bookmark, partial: "bookmark_control", if: :render_bookmarks_control?)
 

--- a/app/helpers/blacklight_helper.rb
+++ b/app/helpers/blacklight_helper.rb
@@ -10,9 +10,8 @@ module BlacklightHelper
   end
 
   def render_default_thumbnail_link(document, options = {})
-    default_thumb = document["preview_ssim"].present? ? (image_tag(document["preview_ssim"].first, alt: document["title_tsim"].to_sentence)) : nil
-
-    return default_thumb
+    return if document["preview_ssim"] == ["NULL"]
+    document["preview_ssim"].present? ? (image_tag(document["preview_ssim"].first, alt: document["title_tsim"].to_sentence)) : nil
   end
 
   def sidebar_classes

--- a/app/presenters/funnel_cake/index_presenter.rb
+++ b/app/presenters/funnel_cake/index_presenter.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class FunnelCake::IndexPresenter < Blacklight::IndexPresenter
+  self.thumbnail_presenter = FunnelCake::ThumbnailPresenter
+end

--- a/app/presenters/funnel_cake/show_presenter.rb
+++ b/app/presenters/funnel_cake/show_presenter.rb
@@ -1,0 +1,5 @@
+# frozen_string_literal: true
+
+class FunnelCake::ShowPresenter < Blacklight::ShowPresenter
+  self.thumbnail_presenter = FunnelCake::ThumbnailPresenter
+end

--- a/app/presenters/funnel_cake/thumbnail_presenter.rb
+++ b/app/presenters/funnel_cake/thumbnail_presenter.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+##
+# Custom Funnel Cake Thumbnail Presenter
+class FunnelCake::ThumbnailPresenter < Blacklight::ThumbnailPresenter
+  private
+
+    # Overriden to skip rendering NULL thumbnails
+    def thumbnail_value_from_document
+      return if @document[thumbnail_field] == ["NULL"]
+      super
+    end
+end

--- a/config/blacklight.yml
+++ b/config/blacklight.yml
@@ -1,6 +1,6 @@
 development:
   adapter: solr
-  url: <%= ENV['SOLR_URL'] || "http://127.0.0.1:8983/solr/blacklight-core-dev" %>
+  url: <%= ENV['SOLR_URL'] %>
   funcake_oai_prod_solr_url: <%= ENV['FUNCAKE_OAI_PROD_SOLR_URL'] || "http://127.0.0.1:8090/solr/funcake-oai-2-dev" %>
   funcake_oai_dev_solr_url: <%= ENV['FUNCAKE_OAI_DEV_SOLR_URL'] || "http://127.0.0.1:8090/solr/funcake-oai-2-prod" %>
 

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,10 +8,16 @@ default: &default
 
 development:
   <<: *default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
   database: funnelcake_development
 
 test:
   <<: *default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
   database: funnelcake_test
 
 production:

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,9 +12,6 @@
 
 ActiveRecord::Schema.define(version: 2019_03_13_201707) do
 
-  # These are extensions that must be enabled in order to support this database
-  enable_extension "plpgsql"
-
   create_table "bookmarks", force: :cascade do |t|
     t.integer "user_id", null: false
     t.string "user_type"


### PR DESCRIPTION
This is one way of fixing issue where a string "NULL" value ends up
causing field rendering to break.  Specifically for the preview field.

But there are better ways I think.

* We should be handling this at indexing time either from the indexer app or
from Solr schema. We should not be indexing "NULL" literal string.

* If not that, we could handle this from the document.