### PR TITLE
FLYPIE-176: Add missing field to facets.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: https://github.com/projectblacklight/blacklight_oai_provider.git
-  revision: 76b6a2ae6fc0068aa93a3035051fb333c4564795
+  revision: 453e91d4df49414c2d01432413b4441dc1e2bcda
   specs:
     blacklight_oai_provider (7.0.0)
       blacklight (~> 7.0)
@@ -347,7 +347,7 @@ GEM
       unf_ext
     unf_ext (0.0.7.7)
     unicode-display_width (2.0.0)
-    view_component (2.28.0)
+    view_component (2.30.0)
       activesupport (>= 5.0.0, < 7.0)
     web-console (3.7.0)
       actionview (>= 5.0)

--- a/app/components/funnel_cake/constraints_component.rb
+++ b/app/components/funnel_cake/constraints_component.rb
@@ -1,0 +1,25 @@
+# frozen_string_literal: true
+
+class FunnelCake::ConstraintsComponent < Blacklight::ConstraintsComponent
+  # Overriden to handle missing facet constraint
+  def facet_item_presenters
+    return to_enum(:facet_item_presenters) unless block_given?
+
+    Deprecation.silence(Blacklight::SearchState) do
+      @search_state.filters.map do |facet|
+        missing_facet = @search_state.params.dig("f", "-#{facet.key}:").present?
+        facet.values.map do |val|
+          next if val.blank? && !missing_facet
+
+          if missing_facet && val.blank?
+            yield facet_item_presenter(facet.config, "[Missing]", facet.key)
+          elsif val.is_a?(Array)
+            yield inclusive_facet_item_presenter(facet.config, val, facet.key) if val.any?(&:present?)
+          else
+            yield facet_item_presenter(facet.config, val, facet.key)
+          end
+        end
+      end
+    end
+  end
+end

--- a/app/controllers/catalog_controller.rb
+++ b/app/controllers/catalog_controller.rb
@@ -4,6 +4,8 @@ class CatalogController < ApplicationController
   before_action(:catalog_params, only: :index)
   include Blacklight::Catalog
 
+  self.search_state_class = FunnelCake::SearchState
+
   configure_blacklight do |config|
     ## Class for sending and receiving requests from a search index
     # config.repository_class = Blacklight::Solr::Repository
@@ -19,6 +21,7 @@ class CatalogController < ApplicationController
 
     ## Default parameters to send to solr for all search-like requests. See also SearchBuilder#processed_parameters
     config.default_solr_params = {
+      "facet.missing": true,
       rows: 10
     }
 

--- a/app/helpers/catalog_helper.rb
+++ b/app/helpers/catalog_helper.rb
@@ -1,0 +1,9 @@
+# frozen_string_literal: true
+
+module CatalogHelper
+  include Blacklight::CatalogHelperBehavior
+
+  def facet_item_presenter(facet_config, facet_item, facet_field)
+    FunnelCake::FacetItemPresenter.new(facet_item, facet_config, self, facet_field)
+  end
+end

--- a/app/lib/funnel_cake/search_state.rb
+++ b/app/lib/funnel_cake/search_state.rb
@@ -1,0 +1,13 @@
+# frozen_string_literal: true
+
+module FunnelCake
+  class SearchState < ::Blacklight::SearchState
+    # Overridden in order to override FilterField class
+    def filter(field_key_or_field)
+      field = field_key_or_field if field_key_or_field.is_a? Blacklight::Configuration::Field
+      field ||= blacklight_config.facet_fields[field_key_or_field]
+      field ||= Blacklight::Configuration::NullField.new(key: field_key_or_field)
+      (field.filter_class || FunnelCake::SearchState::FilterFieldOverride).new(field, self)
+    end
+  end
+end

--- a/app/lib/funnel_cake/search_state/filter_field_override.rb
+++ b/app/lib/funnel_cake/search_state/filter_field_override.rb
@@ -1,0 +1,47 @@
+# frozen_string_literal: true
+
+module FunnelCake
+  class SearchState::FilterFieldOverride < Blacklight::SearchState::FilterField
+    # Overridden to add missing field query logic
+    def remove(item)
+      new_state = search_state.reset_search
+      if item.respond_to?(:field) && item.field != key
+        return new_state.filter(item.field).remove(item)
+      end
+
+      params = new_state.params
+
+      param = :f
+      value = as_url_parameter(item)
+      param = :f_inclusive if value.is_a?(Array)
+
+      # need to dup the facet values too,
+      # if the values aren't dup'd, then the values
+      # from the session will get remove in the show view...
+      params[param] = (params[param] || {}).dup
+      params[param][key] = (params[param][key] || []).dup
+
+      collection = params[param][key]
+      # collection should be an array, because we link to ?f[key][]=value,
+      # however, Facebook (and maybe some other PHP tools) tranform that parameters
+      # into ?f[key][0]=value, which Rails interprets as a Hash.
+      if collection.is_a? Hash
+        Deprecation.warn(self, "Normalizing parameters in FilterField#remove is deprecated")
+        collection = collection.values
+      end
+
+      params[param][key] = collection - Array(value)
+      params[param].delete(key) if params[param][key].empty?
+      params.delete(param) if params[param].empty?
+
+      # Handle missing field queries.
+      if (item.respond_to?(:fq) && item.fq == "-#{key}:[* TO *]") ||
+          item == "[Missing]"
+        params[param].delete("-#{key}:")
+        params[param].delete(key) if params[param][key] == [""]
+      end
+
+      new_state.reset(params)
+    end
+  end
+end

--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -3,11 +3,14 @@
 class SearchBuilder < Blacklight::SearchBuilder
   include Blacklight::Solr::SearchBuilderBehavior
 
-  ##
-  # @example Adding a new step to the processor chain
-  #   self.default_processor_chain += [:add_custom_data_to_query]
-  #
-  #   def add_custom_data_to_query(solr_parameters)
-  #     solr_parameters[:custom] = blacklight_params[:user_value]
-  #   end
+  self.default_processor_chain += [:add_missing_field_query]
+
+  # Build and append a missing field query.
+  def add_missing_field_query(solr_parameters)
+    return unless solr_parameters["facet.missing"]
+
+    solr_parameters[:fq].append(*(blacklight_params["f"] || [])
+      .select { |f| f.match(/^-/) }
+      .map { |k, v| "#{k}[* TO *]" })
+  end
 end

--- a/app/models/solr_document.rb
+++ b/app/models/solr_document.rb
@@ -17,4 +17,15 @@ class SolrDocument
   # and Blacklight::Document::SemanticFields#to_semantic_values
   # Recommendation: Use field names from Dublin Core
   use_extension(Blacklight::Document::DublinCore)
+
+  def initialize(doc, req = nil)
+    # TODO:Remove if/when we do this at indexing time.
+    doc.keys.each do |field|
+      if [ "NULL", ["NULL"], "", [""]].include? doc[field]
+        doc[field] = nil
+      end
+    end
+
+    super
+  end
 end

--- a/app/presenters/funnel_cake/facet_item_presenter.rb
+++ b/app/presenters/funnel_cake/facet_item_presenter.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module FunnelCake
+  class FacetItemPresenter < Blacklight::FacetItemPresenter
+    def missing_facet?
+      facet_field.match?(/^-.*:$/) ||
+        (facet_item.match?(/^-.*:$/) rescue false) ||
+        (facet_item.fq.match?(/^-.*:\[\* TO \*\]$/) rescue false)
+    end
+
+    # Overridden to handle missing_facet case.
+    def selected?
+      if missing_facet?
+        return false if search_state.params.dig("f", "-#{key}:").blank?
+      end
+      super
+    end
+  end
+end

--- a/app/views/catalog/_constraints.html.erb
+++ b/app/views/catalog/_constraints.html.erb
@@ -1,0 +1,2 @@
+<%# Overridden in order to use our own ConstraintComponent %>
+<%= render(FunnelCake::ConstraintsComponent.new(search_state: convert_to_search_state(controller.params != params ? params : search_state))) %>

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,10 +8,16 @@ default: &default
 
 development:
   <<: *default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
   database: funnelcake_development
 
 test:
   <<: *default
+  adapter: sqlite3
+  pool: 5
+  timeout: 5000
   database: funnelcake_test
 
 production:

--- a/config/database.yml
+++ b/config/database.yml
@@ -8,16 +8,10 @@ default: &default
 
 development:
   <<: *default
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
   database: funnelcake_development
 
 test:
   <<: *default
-  adapter: sqlite3
-  pool: 5
-  timeout: 5000
   database: funnelcake_test
 
 production:

--- a/spec/helpers/catalog_helper_spec.rb
+++ b/spec/helpers/catalog_helper_spec.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+
+RSpec.describe CatalogHelper, type: :helper do
+  describe "#facet_item_presenter" do
+
+    it "returns a FunnelCake::FacetItemPresenter" do
+      expect(helper.facet_item_presenter({}, "foo", "bar").class).to eq(FunnelCake::FacetItemPresenter)
+    end
+  end
+end
+
+public
+  def search_state
+  end

--- a/spec/lib/funnel_cake/search_state/filter_field_override_spec.rb
+++ b/spec/lib/funnel_cake/search_state/filter_field_override_spec.rb
@@ -1,0 +1,43 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe Blacklight::SearchState::FilterField do
+  let(:search_state) { FunnelCake::SearchState.new(params.with_indifferent_access, blacklight_config, controller) }
+
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.add_facet_field "some_field"
+      config.add_facet_field "another_field", single: true
+    end
+  end
+  let(:controller) { double }
+
+  describe "#remove" do
+    context "With facet.missing field" do
+      let(:params) do
+        { f: { some_field: [""], "-some_field:": [""] } }
+      end
+
+      it "removes facet.missing facet params" do
+        filter = search_state.filter("some_field")
+        new_state = filter.remove(OpenStruct.new(fq: "-some_field:[* TO *]"))
+
+        expect(new_state.params).to eq("f" => {})
+      end
+    end
+
+    context "With facet.missing field value" do
+      let(:params) do
+        { f: { some_field: [""], "-some_field:": [""] } }
+      end
+
+      it "removes facet.missing facet params" do
+        filter = search_state.filter("some_field")
+        new_state = filter.remove("[Missing]")
+
+        expect(new_state.params).to eq("f" => {})
+      end
+    end
+  end
+end

--- a/spec/lib/funnel_cake/search_state_spec.rb
+++ b/spec/lib/funnel_cake/search_state_spec.rb
@@ -1,0 +1,26 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FunnelCake::SearchState do
+  subject(:search_state) { described_class.new(params, blacklight_config, controller) }
+
+  around { |test| Deprecation.silence(described_class) { test.call } }
+
+  let(:blacklight_config) do
+    Blacklight::Configuration.new.configure do |config|
+      config.index.title_field = "title_tsim"
+      config.index.display_type_field = "format"
+    end
+  end
+
+  let(:parameter_class) { ActionController::Parameters }
+  let(:controller) { double }
+  let(:params) { parameter_class.new }
+
+  describe "#filter" do
+    it "returns a copy of the original parameters" do
+      expect(search_state.filter("foo").class).to eq(FunnelCake::SearchState::FilterFieldOverride)
+    end
+  end
+end

--- a/spec/models/search_builder_spec.rb
+++ b/spec/models/search_builder_spec.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SearchBuilder, api: true do
+  subject(:builder) { described_class.new processor_chain, scope }
+
+  let(:processor_chain) { [] }
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:scope) { double blacklight_config: blacklight_config }
+
+  context "with default processor chain" do
+    subject { described_class.new scope }
+
+    it "appends the :add_missing_field_query processor" do
+      expect(subject.processor_chain).to include(:add_missing_field_query)
+    end
+  end
+
+  describe "#add_missing_field_query" do
+    it "precesses facet.missing query" do
+      subject.with("f" => { "-hello:" => [""] })
+      solr_params = { "facet.missing" => true, fq: [] }
+
+      expect(subject.add_missing_field_query(solr_params)).to eq(["-hello:[* TO *]"])
+    end
+  end
+end

--- a/spec/models/solr_document_spec.rb
+++ b/spec/models/solr_document_spec.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe SolrDocument do
+  describe "null field initialization" do
+
+    context "null field is 'NULL'" do
+      it "sets null field to nil" do
+        doc = described_class.new(null_field: "NULL")
+        expect(doc["null_field"]).to be_nil
+      end
+    end
+
+    context "null field is ['NULL']" do
+      it "sets null field to nil" do
+        doc = described_class.new(null_field: ["NULL"])
+        expect(doc["null_field"]).to be_nil
+      end
+    end
+
+    context "null field is ''" do
+      it "sets null field to nil" do
+        doc = described_class.new(null_field: "")
+        expect(doc["null_field"]).to be_nil
+      end
+    end
+
+    context "null field is ['']" do
+      it "sets null field to nil" do
+        doc = described_class.new(null_field: [""])
+        expect(doc["null_field"]).to be_nil
+      end
+    end
+  end
+end

--- a/spec/presenters/funnel_cake/facet_item_presenter_spec.rb
+++ b/spec/presenters/funnel_cake/facet_item_presenter_spec.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+RSpec.describe FunnelCake::FacetItemPresenter, type: :presenter do
+  subject(:presenter) do
+    described_class.new(facet_item, facet_config, view_context, facet_field, search_state)
+  end
+
+  let(:facet_item) { instance_double(Blacklight::Solr::Response::Facets::FacetItem) }
+  let(:facet_config) { Blacklight::Configuration::FacetField.new(key: "key") }
+  let(:facet_field) { instance_double(Blacklight::Solr::Response::Facets::FacetField) }
+  let(:view_context) { controller.view_context }
+  let(:search_state) { instance_double(FunnelCake::SearchState) }
+  let(:controller) { CatalogController.new }
+  let(:config) { controller.blacklight_config }
+
+  describe "#selected?" do
+    context "with missing facet field but no missing facet param" do
+      let(:search_state) { FunnelCake::SearchState.new({}, config) }
+      it "works" do
+        allow(presenter).to receive(:missing_facet?).and_return(true)
+        allow(search_state).to receive(:has_facet?).and_return(true)
+        expect(presenter.selected?).to be false
+      end
+    end
+
+    context "with missing facet field and missing facet param" do
+      let(:search_state) { FunnelCake::SearchState.new({ f: { "-key:" => [""] } }, config) }
+      it "works" do
+        allow(presenter).to receive(:missing_facet?).and_return(true)
+        allow(search_state).to receive(:has_facet?).and_return(true)
+        expect(presenter.selected?).to be true
+      end
+    end
+  end
+end


### PR DESCRIPTION
This is a better alternative to #118.

* Handles all cases for missing field.
* Handles the errors at the data level.
* Handles adding and removing missing field facet.
* Handles the missing field constraints