### PR TITLE
FLYPIE-271: Fix getting oai record fails.

### DIFF
--- a/app/controllers/dpla_oai_controller.rb
+++ b/app/controllers/dpla_oai_controller.rb
@@ -26,8 +26,10 @@ class DplaOaiController < ApplicationController
       qt: "search",
       fl: "*",
       rows: 1,
-      q: "{!raw f=id v=$id}"
+      facet: false,
     }
+    config.document_unique_id_param = "id"
+    config.document_solr_path = "select"
     config.connection_config = config.connection_config.dup
     config.connection_config[:url] = config.connection_config[:funcake_oai_prod_solr_url]
     config.document_model = OaiDocument

--- a/app/controllers/internal_oai_controller.rb
+++ b/app/controllers/internal_oai_controller.rb
@@ -26,8 +26,10 @@ class InternalOaiController < ApplicationController
       qt: "search",
       fl: "*",
       rows: 1,
-      q: "{!raw f=id v=$id}"
+      facet: false,
     }
+    config.document_unique_id_param = "id"
+    config.document_solr_path = "select"
     config.connection_config = config.connection_config.dup
     config.connection_config[:url] = config.connection_config[:funcake_oai_dev_solr_url]
     config.document_model = OaiDocument


### PR DESCRIPTION
The regular old get method for solr document doesn't seem to be working
for oai records.  I think this is because the records are in
  a multi-collection alias.

Updating the document solr config to use the regular search path works.