### PR TITLE
FLYPIE-271: Fix fetch record fails.

### DIFF
--- a/app/controllers/dpla_oai_controller.rb
+++ b/app/controllers/dpla_oai_controller.rb
@@ -4,6 +4,8 @@ class DplaOaiController < ApplicationController
   include Blacklight::Catalog
   include BlacklightOaiProvider::Controller
 
+  self.search_service_class = FunnelCake::SearchService
+
   configure_blacklight do |config|
     config.oai = {
       repository_url: "/oai",

--- a/app/controllers/internal_oai_controller.rb
+++ b/app/controllers/internal_oai_controller.rb
@@ -4,6 +4,8 @@ class InternalOaiController < ApplicationController
   include Blacklight::Catalog
   include BlacklightOaiProvider::Controller
 
+  self.search_service_class = FunnelCake::SearchService
+
   configure_blacklight do |config|
     config.oai = {
       repository_url: "/oai_dev",

--- a/app/services/funnel_cake/search_service.rb
+++ b/app/services/funnel_cake/search_service.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+module FunnelCake
+  class SearchService < ::Blacklight::SearchService
+    # Overridden as workaround to Solr RealTime Get not working.
+    # REF #FLYPIE-271
+    #
+    # @TODO: remove once we get Solr RealTime Get working for FunnelCake OAI.
+    def fetch_one(id, params = {})
+      solr_response = repository.send_and_receive("select", { fq: "id:#{id.gsub(":", "\\:")}" }
+        .reverse_merge(params))
+      [solr_response, solr_response.documents.first]
+    end
+  end
+end

--- a/spec/services/funnel_cake/search_service_spec.rb
+++ b/spec/services/funnel_cake/search_service_spec.rb
@@ -1,0 +1,56 @@
+# frozen_string_literal: true
+
+require "rails_helper"
+
+# check the methods that do solr requests. Note that we are not testing if
+#  solr gives "correct" responses, as that's out of scope (it's a part of
+#  testing the solr code itself).  We *are* testing if blacklight code sends
+#  queries to solr such that it gets appropriate results. When a user does a search,
+#  do we get data back from solr (i.e. did we properly configure blacklight code
+#  to talk with solr and get results)? when we do a document request, does
+#  blacklight code get a single document returned?)
+#
+RSpec.describe FunnelCake::SearchService, api: true do
+  subject { service }
+
+  let(:context) { { whatever: :value } }
+  let(:service) { described_class.new(config: blacklight_config, user_params: user_params, **context) }
+  let(:repository) { Blacklight::Solr::Repository.new(blacklight_config) }
+  let(:user_params) { {} }
+
+  let(:blacklight_config) { Blacklight::Configuration.new }
+  let(:copy_of_catalog_config) { ::CatalogController.blacklight_config.deep_copy }
+  let(:blacklight_solr) { RSolr.connect(Blacklight.connection_config.except(:adapter)) }
+  let(:solr_response) { double Blacklight::Solr::Response }
+
+  let(:all_docs_query) { "" }
+  let(:no_docs_query) { "zzzzzzzzzzzz" }
+  #  f[format][]=Book&f[language_facet][]=English
+  let(:single_facet) { { format: "Book" } }
+
+  before do
+    allow(service).to receive(:repository).and_return(repository)
+    allow(solr_response).to receive(:documents).and_return([])
+    service.repository.connection = blacklight_solr
+  end
+
+  describe "#fetch_one" do
+
+    context "fetch with out extra params" do
+      it "remove" do
+        allow(repository).to receive(:send_and_receive).and_return(solr_response)
+        service.send(:fetch_one, "foo:bar")
+        expect(repository).to have_received(:send_and_receive).with("select", { fq: "id:foo\\:bar" })
+      end
+    end
+
+    context "fetch with extra params" do
+      it "remove" do
+        allow(repository).to receive(:send_and_receive).and_return(solr_response)
+        service.send(:fetch_one, "foo:bar", { "bizz" => "buzz" })
+        expect(repository).to have_received(:send_and_receive).with("select", { fq: "id:foo\\:bar", "bizz" => "buzz" })
+      end
+    end
+
+  end
+end


### PR DESCRIPTION
The RealTime Get feature for the funcake oai collection is broken and
it's not obvious why this is happening.

This is hopefully a temporary work around that uses a `select?fq=id:<id>` to fetch single records.

The `select` search handler uses a less efficient process for getting
single record so it would be good if we can fix RealTime Get on the OAI
collections.