### PR TITLE
Fix broken upgrade to bl-7.19

### DIFF
--- a/app/models/search_builder.rb
+++ b/app/models/search_builder.rb
@@ -9,7 +9,7 @@ class SearchBuilder < Blacklight::SearchBuilder
   def add_missing_field_query(solr_parameters)
     return unless solr_parameters["facet.missing"]
 
-    solr_parameters[:fq].append(*(blacklight_params["f"] || [])
+    (solr_parameters[:fq] || []).append(*(blacklight_params["f"] || [])
       .select { |f| f.match(/^-/) }
       .map { |k, v| "#{k}[* TO *]" })
   end


### PR DESCRIPTION
Upstream BL now does not return [] by default for un configured solr
parameters.