### PR TITLE
FLYPIE-283 Make Export tags compatible with Bootstrap 5.1

### DIFF
--- a/app/views/catalog/_export_as.html.erb
+++ b/app/views/catalog/_export_as.html.erb
@@ -1,4 +1,4 @@
-<span class="sr-only"> Export as CSV </span>
+<span class="sr-only visually-hidden"> Export as CSV </span>
 <div id="export_as-dropdown" class="btn-group export-as-dropdown">
   <button name="button" type="submit" class="btn dropdown-toggle" aria-expanded="false" data-toggle="dropdown" data-bs-toggle="dropdown">
     <%= t("funnelcake.export_as") %><span class="d-none d-sm-inline"></span><span class="caret">

--- a/app/views/catalog/_sort_and_per_page.html.erb
+++ b/app/views/catalog/_sort_and_per_page.html.erb
@@ -1,5 +1,5 @@
 <div id="sortAndPerPage" class="sort-pagination clearfix">
   <%= render partial: "paginate_compact", object: @response if show_pagination? %>
-  <%= render_results_collection_tools wrapping_class: "search-widgets float-md-right" %>
+  <%= render_results_collection_tools wrapping_class: "search-widgets float-md-end" %>
   <%= render partial: "export_as" %>
 </div>


### PR DESCRIPTION
Use Bootstrap 5.1 selectors to properly align widgets and hide labels.