### PR TITLE
Reverse Funnelcake Index bump

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,7 +10,7 @@ GIT
 
 GIT
   remote: https://github.com/tulibraries/funnel_cake_index.git
-  revision: 3fa8ddb9fd15cdb5eea4a92b7c15ebf94adb0f9f
+  revision: 07e55df8e249e65246098f379c7397f6a7a7bd4d
   specs:
     funnel_cake_index (0.0.1)
       gli (~> 2.18)
@@ -86,12 +86,12 @@ GEM
       i18n (>= 1.6, < 2)
       minitest (>= 5.1)
       tzinfo (~> 2.0)
-    addressable (2.8.6)
+    addressable (2.8.5)
       public_suffix (>= 2.0.2, < 6.0)
     ast (2.4.2)
     autoprefixer-rails (10.4.13.0)
       execjs (~> 2)
-    base64 (0.2.0)
+    base64 (0.1.1)
     bindex (0.8.1)
     blacklight (7.33.1)
       deprecation
@@ -129,7 +129,8 @@ GEM
     deprecation (1.1.0)
       activesupport
     diff-lcs (1.5.0)
-    domain_name (0.6.20231109)
+    domain_name (0.5.20190701)
+      unf (>= 0.0.5, < 1.0.0)
     dot-properties (0.1.4)
       bundler (>= 2.2.33)
     dotenv (2.8.1)
@@ -138,7 +139,7 @@ GEM
       railties (>= 3.2)
     erubi (1.12.0)
     execjs (2.8.1)
-    faraday (2.8.1)
+    faraday (2.7.11)
       base64
       faraday-net_http (>= 2.0, < 3.1)
       ruby2_keywords (>= 0.0.4)
@@ -247,7 +248,7 @@ GEM
       method_source (~> 1.0)
     pry-rails (0.3.9)
       pry (>= 0.10.4)
-    public_suffix (5.0.4)
+    public_suffix (5.0.3)
     puma (6.4.0)
       nio4r (~> 2.0)
     racc (1.7.3)
@@ -385,7 +386,7 @@ GEM
       execjs (>= 0.3.0, < 3)
     unf (0.1.4)
       unf_ext
-    unf_ext (0.0.9.1)
+    unf_ext (0.0.8.2)
     unicode-display_width (2.5.0)
     vcr (6.2.0)
     view_component (2.82.0)


### PR DESCRIPTION
- Base64 2.0 breaks deploy
- Recent Funnelcake Index Bump was "Bump rubocop from 1.57.2 to 1.59.0"