### PR TITLE
Fix gitlab pipeline

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -155,7 +155,9 @@ GEM
       faraday (>= 1, < 3)
     faraday-net_http (3.1.0)
       net-http
+    ffi (1.17.0-x86_64-darwin)
     ffi (1.17.0-x86_64-linux-gnu)
+    ffi (1.17.0-x86_64-linux-musl)
     ffi-compiler (1.3.2)
       ffi (>= 1.15.5)
       rake
@@ -246,6 +248,8 @@ GEM
     net-smtp (0.5.0)
       net-protocol
     nio4r (2.7.3)
+    nokogiri (1.16.6-x86_64-darwin)
+      racc (~> 1.4)
     nokogiri (1.16.6-x86_64-linux)
       racc (~> 1.4)
     oai (1.2.1)
@@ -387,7 +391,9 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
+    sqlite3 (2.0.2-x86_64-darwin)
     sqlite3 (2.0.2-x86_64-linux-gnu)
+    sqlite3 (2.0.2-x86_64-linux-musl)
     stringio (3.1.1)
     strscan (3.1.0)
     thor (1.3.1)
@@ -444,7 +450,9 @@ GEM
     zeitwerk (2.6.16)
 
 PLATFORMS
+  x86_64-darwin-22
   x86_64-linux
+  x86_64-linux-musl
 
 DEPENDENCIES
   base64 (= 0.2.0)
@@ -487,4 +495,4 @@ DEPENDENCIES
   webmock
 
 BUNDLED WITH
-   2.5.10
+   2.5.6


### PR DESCRIPTION
We are getting this error in the pipeline: Could not find gem 'ffi (= 1.17.0)' with platform 'x86_64-linux' in rubygems

According to this issue, we need to add the linux-musl platform for alpine. https://github.com/ffi/ffi/issues/1105