### PR TITLE
Set version of application to CI_TAG

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -108,4 +108,4 @@ prod_deploy:
     - tags
   script:
     - helm pull oci://$HARBOR/tulibraries/charts/padigital --version $HELM_VERSION_PROD --untar
-    - helm upgrade padigital oci://$HARBOR/tulibraries/charts/padigital --version $HELM_VERSION_PROD --history-max=5 --namespace=padigital-prod --values padigital/values-prod.yaml --set image.repository=$IMAGE:$CI_COMMIT_TAG
+    - helm upgrade padigital oci://$HARBOR/tulibraries/charts/padigital --version $CI_COMMIT_TAG --history-max=5 --namespace=padigital-prod --values padigital/values-prod.yaml --set image.repository=$IMAGE:$CI_COMMIT_TAG


### PR DESCRIPTION
helm --version sets the version of the app and in some versions of helm overrides the app image version.